### PR TITLE
Add const static variable for the hardcode status string

### DIFF
--- a/backend/api/models/const.py
+++ b/backend/api/models/const.py
@@ -1,0 +1,23 @@
+class DocumentDisplayStatusConst:
+    REPORTED = "已檢舉"
+    AUDIT_SCHEDULED = "已排程稽查"
+    COMMUNICATION_PERIOD = "陳述意見期"
+    WORK_STOPPED = "已勒令停工"
+    POWER_OUTING = "已發函斷電"
+    POWER_OUTED = "已斷電"
+    DEMOLITION_SCHEDULED = "已排程拆除"
+    DEMOLISHED = "已拆除"
+    WAITING_FOR_NEW_EVIDENCE = "等待新事證"
+    IN_PROGRESS = "處理中"
+    OPEN = "未處理"
+
+    STATUS_LIST = [REPORTED,
+                   AUDIT_SCHEDULED,
+                   COMMUNICATION_PERIOD,
+                   WORK_STOPPED,
+                   POWER_OUTING,
+                   DEMOLITION_SCHEDULED,
+                   DEMOLISHED,
+                   WAITING_FOR_NEW_EVIDENCE]
+
+    STATUS_LIST_ENRICHMENT = STATUS_LIST + [IN_PROGRESS]

--- a/backend/api/models/document.py
+++ b/backend/api/models/document.py
@@ -4,24 +4,12 @@ from .mixins import SoftDeleteMixin
 from .factory import Factory
 
 from users.models import CustomUser
+from .const import DocumentDisplayStatusConst
 
 
 class DocumentDisplayStatusEnum:
 
-    CHOICES = list(
-        enumerate(
-            [
-                "已檢舉",
-                "已排程稽查",
-                "陳述意見期",
-                "已勒令停工",
-                "已發函斷電",
-                "已排程拆除",
-                "已拆除",
-                "等待新事證",
-            ]
-        )
-    )
+    CHOICES = list(enumerate(DocumentDisplayStatusConst.STATUS_LIST))
     INDICES = {val: idx for idx, val in CHOICES}
 
 
@@ -79,7 +67,7 @@ class Document(SoftDeleteMixin):
 
     created_at = models.DateTimeField(auto_now_add=True)
     display_status = models.IntegerField(
-        default=DocumentDisplayStatusEnum.INDICES["已檢舉"],
+        default=DocumentDisplayStatusEnum.INDICES[DocumentDisplayStatusConst.REPORTED],
         choices=DocumentDisplayStatusEnum.CHOICES,
         db_index=True,
     )


### PR DESCRIPTION
Rebased/cherry-picked necessary commits from https://github.com/tai271828/disfactory-backend/pull/6


**Unittest result**

```
================================================== warnings summary ==================================================
towninfo/__init__.py:37: 22 warnings
  /Disfactory/towninfo/__init__.py:37: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
    for child in tree.getchildren():

api/tests/test_serializers.py::TestFactorySerializers::test_factory_serializer_correct_report_date
  /usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1427: RuntimeWarning: DateTimeField Factory.status_time received a naive datetime (2021-12-05 06:10:22.877965) while time zone support is active.
    RuntimeWarning)

api/views/tests/test_factory_image_c.py::TestPostFactoryImageView::test_image_upload_db_correct
api/views/tests/test_image_c.py::test_post_image_url
  /usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1427: RuntimeWarning: DateTimeField Image.orig_time received a naive datetime (2020-03-21 12:33:59) while time zone support is active.
    RuntimeWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================== 54 passed, 1 skipped, 25 warnings in 10.44s =====================================
```