### PR TITLE
Added new display name on the admin site for the factory model

### DIFF
--- a/backend/api/models/factory.py
+++ b/backend/api/models/factory.py
@@ -137,6 +137,10 @@ class Factory(SoftDeleteMixin):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    class Meta:
+        verbose_name = "Ohshown Event"
+        verbose_name_plural = "Ohshown Events"
+
 
 class RecycledFactory(Factory):
     class Meta:


### PR DESCRIPTION
Issue 9: Change the display model name of 'Factorys' to 'Ohshown Events' on the Django Admin site. 
How: Added verbose_name and verbose_name_plural as additional meta for the Factory model.