### PR TITLE
Add new api endpoint for getting ohshown-event-type list resource

### DIFF
--- a/backend/api/models/const.py
+++ b/backend/api/models/const.py
@@ -21,3 +21,18 @@ class DocumentDisplayStatusConst:
                    WAITING_FOR_NEW_EVIDENCE]
 
     STATUS_LIST_ENRICHMENT = STATUS_LIST + [IN_PROGRESS]
+
+
+class OhshownEventConst:
+    TYPE_LIST = [
+        ('2-1', '痕跡: 爪痕'),
+        ('2-2', '痕跡: 排遺'),
+        ('2-3', '痕跡: 植物折痕'),
+        ('3', '人熊衝突現場痕跡 - 雞舍'),
+        ('4', '人熊衝突現場痕跡 - 果園'),
+        ('5', '人熊衝突現場痕跡 - 其他'),
+        ('6', '死亡'),
+        ('7', '現場目擊 - 不確定'),
+        ('8', '現場目擊 - 確定'),
+        ('9', '其他')
+    ]

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -26,6 +26,7 @@ from .views import (
     get_images_count_by_townname,
     get_report_records_count_by_townname,
     get_statistics_total,
+    get_ohshown_event_type_list,
 )
 
 urlpatterns = [
@@ -39,4 +40,5 @@ urlpatterns = [
     path("statistics/report_records", get_report_records_count_by_townname),
     path("statistics/total", get_statistics_total),
     path("images", post_image_url),
+    path("resources/ohshown-event-type", get_ohshown_event_type_list),
 ]

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -7,3 +7,4 @@ from .statistics_r import get_factories_count_by_townname
 from .statistics_r import get_images_count_by_townname
 from .statistics_r import get_report_records_count_by_townname
 from .statistics_r import get_statistics_total
+from .resource import get_ohshown_event_type_list

--- a/backend/api/views/resource.py
+++ b/backend/api/views/resource.py
@@ -1,0 +1,28 @@
+from rest_framework.decorators import api_view
+
+from django.http import JsonResponse
+
+from ..models.const import OhshownEventConst
+
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+
+@swagger_auto_schema(
+    method="get",
+    operation_summary="Get Ohshown event type list",
+    responses={200: openapi.Response("results", openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            "value": openapi.Schema(type=openapi.TYPE_STRING, description="Ohshown event type value"),
+            "text": openapi.Schema(type=openapi.TYPE_STRING, description="Ohshown event type text")
+        },
+    )), 400: "request failed"},
+)
+@api_view(["GET"])
+def get_ohshown_event_type_list(request):
+    return JsonResponse(_to_value_and_text_format(OhshownEventConst.TYPE_LIST), safe=False)
+
+
+def _to_value_and_text_format(resource_tuple_list):
+    return [{"value": resource_tuple[0], "text": resource_tuple[1]} for resource_tuple in resource_tuple_list]

--- a/backend/api/views/tests/test_resource.py
+++ b/backend/api/views/tests/test_resource.py
@@ -1,0 +1,12 @@
+import pytest
+from ...models.const import OhshownEventConst
+
+@pytest.mark.django_db
+def test_get_ohshown_event_type_list(client):
+    resp = client.get("/api/resources/ohshown-event-type")
+    resp_json = resp.json()
+    expect_list = OhshownEventConst.TYPE_LIST
+    assert len(resp_json) == len(expect_list)
+    for expect, actual in zip(expect_list, resp_json):
+        assert expect[0] == actual['value']
+        assert expect[1] == actual['text']


### PR DESCRIPTION
# Why
- To define the ohshown-event-type resource in one place. (Part of issue https://github.com/tai271828/disfactory-backend/issues/15).
# What
- Define the ohshown-event-type resource in BE and add an api endpoint for FE to get it.
# How
- Port the ohshown-event-type list resource from `src/types.ts` in the FE project to the BE project and add a GET api for it.
# Test
- Check the new api endpoint `[{host}](http://127.0.0.1:8888)/api/resources/ohshown-event-type` worked well locally. (The swagger page http://127.0.0.1:8888/swagger/)
![image](https://user-images.githubusercontent.com/94128872/147881924-4d11a46d-c922-4a1f-9335-a121817dea01.png)
![image](https://user-images.githubusercontent.com/94128872/147881935-46fa2bd0-3e31-4e20-872d-467482217a59.png)
