### PR TITLE
Rename map descriptions & links in the admin page 

### DIFF
--- a/backend/api/admin/ohshown_event.py
+++ b/backend/api/admin/ohshown_event.py
@@ -220,7 +220,7 @@ class OhshownEventAdmin(
         "created_at",
         "updated_at",
         "google_map_link",
-        "disfactory_map_link",
+        "ohshown_map_link",
         "follow_ups_for_user",
     )
     fieldsets = (
@@ -246,7 +246,7 @@ class OhshownEventAdmin(
                     ("sectname", "sectcode"),
                     ("lng", "lat"),
                     "google_map_link",
-                    "disfactory_map_link",
+                    "ohshown_map_link",
                     "ohshown_event_type",
                     "name",
                     ("created_at", "updated_at"),
@@ -279,12 +279,12 @@ class OhshownEventAdmin(
         return format_html(html_template.format(lat=obj.lat, lng=obj.lng))
 
     @set_function_attributes(short_description="Ohshown Map 連結")
-    def disfactory_map_link(self, obj):
-        disfactory_frontend_domain = os.environ.get(
-            "DISFACTORY_FRONTEND_DOMAIN", "http://ohshown.site:8080/"
+    def ohshown_map_link(self, obj):
+        ohshown_frontend_domain = os.environ.get(
+            "OHSHOWN_FRONTEND_DOMAIN", "http://ohshown.site:8080/"
         )
 
-        url = urljoin(disfactory_frontend_domain, f"/#map=16.00/{obj.lng}/{obj.lat}")
+        url = urljoin(ohshown_frontend_domain, f"/#map=16.00/{obj.lng}/{obj.lat}")
 
         html_template = f"<a href='{url}' target='_blank'>Link</a>"
 

--- a/backend/api/admin/ohshown_event.py
+++ b/backend/api/admin/ohshown_event.py
@@ -278,10 +278,10 @@ class OhshownEventAdmin(
 
         return format_html(html_template.format(lat=obj.lat, lng=obj.lng))
 
-    @set_function_attributes(short_description="Disfactory Map 連結")
+    @set_function_attributes(short_description="Ohshown Map 連結")
     def disfactory_map_link(self, obj):
         disfactory_frontend_domain = os.environ.get(
-            "DISFACTORY_FRONTEND_DOMAIN", "https://disfactory.tw/"
+            "DISFACTORY_FRONTEND_DOMAIN", "http://ohshown.site:8080/"
         )
 
         url = urljoin(disfactory_frontend_domain, f"/#map=16.00/{obj.lng}/{obj.lat}")


### PR DESCRIPTION
Re: Issue #20. 

Replace the old 'disfactory' in descriptions and links with 'ohshown' and the new dev site link in the 'Ohshown Events' page of the admin site. 

### Preview
![image](https://user-images.githubusercontent.com/18521262/151070245-678f5620-f4d6-4120-95b0-14e610a1e0ee.png)

### Test
Admin console --> 'Ohshown Events' page--> Check 'Ohshown Map 連結' and see if the corresponding link take you to the ohshown development site map

### Additional Information 
There is no issue now, but it would be good to define 'OHSHOWN_FRONTEND_DOMAIN' in '.env' when the production site is fully set up.