### PR TITLE
Remove the urban address in Ohshown Event Admin UI view

### DIFF
--- a/backend/api/admin/ohshown_event.py
+++ b/backend/api/admin/ohshown_event.py
@@ -242,8 +242,6 @@ class OhshownEventAdmin(
             {
                 "classes": (),
                 "fields": (
-                    ("townname", "landcode"),
-                    ("sectname", "sectcode"),
                     ("lng", "lat"),
                     "google_map_link",
                     "ohshown_map_link",


### PR DESCRIPTION
# why
For issue https://github.com/tai271828/disfactory-backend/issues/26
# what
Remove the urban address in Ohshown Event Admin UI view
# how
Simply modify the fieldsets in `admin/ohshown_event.py`. (Note: It might be a mess code change if we want to remove all of the related code in the backend)
# Test
Checked the detail section in ohshown event admin UI.
Before
![image](https://user-images.githubusercontent.com/94128872/151687233-3e3bf334-2121-4d56-bc1b-7cf2bdd0cb44.png)
After
![image](https://user-images.githubusercontent.com/94128872/151687241-ebbff473-131e-471f-8bbd-2b201ebd7906.png)
