### PR TITLE
Rename get and create factories API to ohshown-event

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -17,7 +17,7 @@ from api.views.factories_cr import get_factory_by_sectcode
 from django.urls import path
 
 from .views import (
-    get_nearby_or_create_factories,
+    get_nearby_or_create_ohshown_events,
     update_factory_attribute,
     get_factory_report,
     post_image_url,
@@ -30,7 +30,7 @@ from .views import (
 )
 
 urlpatterns = [
-    path("factories", get_nearby_or_create_factories),
+    path("ohshown-events", get_nearby_or_create_ohshown_events),
     path("sectcode", get_factory_by_sectcode),
     path("factories/<factory_id>", update_factory_attribute),
     path("factories/<factory_id>/report_records", get_factory_report),

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -1,4 +1,4 @@
-from .factories_cr import get_nearby_or_create_factories, get_factory_by_sectcode
+from .factories_cr import get_nearby_or_create_ohshown_events, get_factory_by_sectcode
 from .factories_u import update_factory_attribute
 from .factory_report_record_r import get_factory_report
 from .image_c import post_image_url

--- a/backend/api/views/factories_cr.py
+++ b/backend/api/views/factories_cr.py
@@ -37,7 +37,7 @@ def _all_image_id_exist(image_ids: List[str]) -> bool:
     return len(images) == len(image_ids)
 
 
-def _handle_get_factories(request):
+def _handle_get_ohshown_events(request):
     try:
         latitude = request.GET["lat"]  # 緯度: y
         longitude = request.GET["lng"]  # 經度: x
@@ -76,7 +76,7 @@ def _handle_get_factories(request):
     serializer = FactorySerializer(nearby_factories, many=True)
     return JsonResponse(serializer.data, safe=False)
 
-def _handle_create_factory(request):
+def _handle_create_ohshown_events(request):
     post_body = request.data
     user_ip = _get_client_ip(request)
 
@@ -172,11 +172,11 @@ def _handle_create_factory(request):
     auto_schema=None,
 )
 @api_view(["GET", "POST"])
-def get_nearby_or_create_factories(request):
+def get_nearby_or_create_ohshown_events(request):
     if request.method == "GET":
-        return _handle_get_factories(request)
+        return _handle_get_ohshown_events(request)
     elif request.method == "POST":
-        return _handle_create_factory(request)
+        return _handle_create_ohshown_events(request)
 
 @swagger_auto_schema(
     method="get",

--- a/backend/api/views/tests/test_factory_cr.py
+++ b/backend/api/views/tests/test_factory_cr.py
@@ -17,25 +17,25 @@ pytestmark = pytest.mark.django_db
 
 def test_get_nearby_factory_wrong_params(client):
     # case 1: missing parameter
-    resp = client.get("/api/factories?lat=23")
+    resp = client.get("/api/ohshown-events?lat=23")
     assert resp.status_code == 400
     assert resp.content == b"Missing query parameter: lng, range."
 
-    resp = client.get("/api/factories?lng=121&range=0.2")
+    resp = client.get("/api/ohshown-events?lng=121&range=0.2")
     assert resp.status_code == 400
     assert resp.content == b"Missing query parameter: lat."
 
     # case 2: not querying Taiwan
-    resp = client.get("/api/factories?lat=39.9046126&lng=116.3977254&range=1")
+    resp = client.get("/api/ohshown-events?lat=39.9046126&lng=116.3977254&range=1")
     assert resp.status_code == 400
     assert b"The query position is not in the range of Taiwan." in resp.content
 
     # case 3: wrong query radius
-    resp = client.get("/api/factories?lat=23&lng=121&range=10000")
+    resp = client.get("/api/ohshown-events?lat=23&lng=121&range=10000")
     assert resp.status_code == 400
     assert resp.content == b"`range` should be within 0.01 to 100 km, but got 10000.0"
 
-    resp = client.get("/api/factories?lat=23&lng=121&range=0.001")
+    resp = client.get("/api/ohshown-events?lat=23&lng=121&range=0.001")
     assert resp.status_code == 400
     assert resp.content == b"`range` should be within 0.01 to 100 km, but got 0.001"
 
@@ -46,7 +46,7 @@ def test_get_nearby_factory_called_util_func_correctly(client):
         lat = 23.12
         lng = 121.5566
         r = 0.5
-        client.get(f"/api/factories?lat={lat}&lng={lng}&range={r}")
+        client.get(f"/api/ohshown-events?lat={lat}&lng={lng}&range={r}")
 
         mock_func.assert_called_once_with(
             latitude=lat,
@@ -61,7 +61,7 @@ def test_get_nearby_factory_called_on_test_data(client):
     lat = 23.234
     lng = 120.1
     r = 1
-    resp = client.get(f"/api/factories?lat={lat}&lng={lng}&range={r}")
+    resp = client.get(f"/api/ohshown-events?lat={lat}&lng={lng}&range={r}")
     assert resp.status_code == 200
 
     factories = resp.json()
@@ -107,7 +107,7 @@ def test_create_new_factory_db_status_correct(client):
     test_time = datetime.datetime(2019, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc)
     with freeze_time(test_time):
         resp = client.post(
-            "/api/factories", data=request_body, content_type="application/json"
+            "/api/ohshown-events", data=request_body, content_type="application/json"
         )
 
     assert resp.status_code == 200
@@ -150,7 +150,7 @@ def test_create_new_factory_raise_if_image_id_not_exist(client):
         "nickname": "路過的家庭主婦",
         "contact": "07-7533967",
     }
-    resp = client.post("/api/factories", data=request_body, content_type="application/json")
+    resp = client.post("/api/ohshown-events", data=request_body, content_type="application/json")
 
     assert resp.status_code == 400
     assert resp.content == b"please check if every image id exist"
@@ -166,7 +166,7 @@ def test_create_new_factory_allow_no_contact(client):
         "lng": 120.1,
         "nickname": "",
     }
-    resp = client.post("/api/factories", data=request_body, content_type="application/json")
+    resp = client.post("/api/ohshown-events", data=request_body, content_type="application/json")
 
     assert resp.status_code == 200
 
@@ -180,7 +180,7 @@ def test_create_new_factory_allow_empty_type(client):
         "lng": 120.1,
         "nickname": "",
     }
-    resp = client.post("/api/factories", data=request_body, content_type="application/json")
+    resp = client.post("/api/ohshown-events", data=request_body, content_type="application/json")
 
     assert resp.status_code == 200
 
@@ -196,7 +196,7 @@ def test_create_new_factory_raise_if_not_in_Taiwan(client):
         "nickname": "",
         "contact": "07-7533967",
     }
-    resp = client.post("/api/factories", data=request_body, content_type="application/json")
+    resp = client.post("/api/ohshown-events", data=request_body, content_type="application/json")
 
     assert resp.status_code == 400
     assert "lat" in resp.json()
@@ -221,7 +221,7 @@ def test_create_new_factory_raise_if_type_is_not_invalid(client):
         "contact": contact,
     }
 
-    resp = client.post("/api/factories", data=request_body, content_type="application/json")
+    resp = client.post("/api/ohshown-events", data=request_body, content_type="application/json")
 
     assert resp.status_code == 400
     assert "type" in resp.json()
@@ -263,7 +263,7 @@ def test_create_factory_after_delete_the_latest_factory_with_maximum_display_num
     test_time = datetime.datetime(2019, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc)
     with freeze_time(test_time):
         resp = client.post(
-            "/api/factories", data=request_body, content_type="application/json"
+            "/api/ohshown-events", data=request_body, content_type="application/json"
         )
 
     assert resp.status_code == 200

--- a/backend/api/views/tests/test_statistics_r.py
+++ b/backend/api/views/tests/test_statistics_r.py
@@ -46,7 +46,7 @@ def create_factory(cli):
     test_time = datetime.datetime(2019, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc)
     with freeze_time(test_time):
         resp = cli.post(
-            "/api/factories", data=request_body, content_type="application/json"
+            "/api/ohshown-events", data=request_body, content_type="application/json"
         )
         data = resp.json()
         update_landcode_with_custom_factory_model(data["id"])


### PR DESCRIPTION
# Why
- For subtask in issue #44 - Rename get and create factories API to ohshown-event
# What
- Rename the API endpoint url
# How
- Rename the API endpoint `{host}/server/api/factories` to `{host}/server/api/ohshown-events`
- Fix the unit test.
# Test
- Pass unit test
- Sanity check with the FE locally (modified locally to call the new API endpoint), looks good.
![image](https://user-images.githubusercontent.com/94128872/158055429-27e87274-e6ec-4fdb-a2b6-5c05cb88d17b.png)
